### PR TITLE
zinit-zsh: Use the new for-syntax

### DIFF
--- a/zsh/plunks/zinit-zsh.zsh
+++ b/zsh/plunks/zinit-zsh.zsh
@@ -1,35 +1,27 @@
 
 # build requirement of yodl:
 function zinit-setup-icmake () {
-  zinit ice nocompletions blockf nocompile \
-    from"gl" id-as"zsh-dep-yodl-icmake" \
-    as"program" pick"$ZPFX/usr/bin/*" \
-    atclone"cd icmake && ./icm_prepare '$ZPFX' && ./icm_bootstrap x && ./icm_install all /" \
-    atpull"%atclone"
-
-  zinit load "fbb-git/icmake"
+  zinit id-as"zsh-dep-yodl-icmake" from"gl" nocompile \
+    nocompletions as"program" pick'$ZPFX/usr/bin/*' \
+    atclone"cd icmake && ./icm_prepare '\$ZPFX' && ./icm_bootstrap x && ./icm_install all /" \
+    atpull"%atclone" for @fbb-git/icmake
 }
 
 # docs requirement of zsh:
 function zinit-setup-yodl () {
   zinit-setup-icmake
 
-  zinit ice nocompletions blockf nocompile \
-    from"gl" id-as"zsh-dep-yodl" \
-    as"program" pick"$ZPFX/usr/bin/*" \
-    atclone"cd yodl && sed -i 's;= \"/usr\";= \"$ZPFX\";' INSTALL.im && sed -i '1s;/usr/bin/icmake;/usr/bin/env -S icmake;' build && ./build programs && ./build install programs '$ZPFX'"
-
-  zinit load "fbb-git/yodl"
+  zinit id-as"zsh-dep-yodl" from"gl" nocompile \
+    nocompletions as"program" pick'$ZPFX/usr/bin/*' \
+    atclone"cd yodl && sed -i 's;= \"/usr\";= \"\$ZPFX\";' INSTALL.im && sed -i '1s;/usr/bin/icmake;/usr/bin/env -S icmake;' build && ./build programs && ./build install programs '\$ZPFX'" \
+        for @fbb-git/yodl
 }
 
 function zinit-setup-zsh () {
   zinit-setup-yodl
 
-  zinit ice nocompletions blockf nocompile \
-    from"gh" id-as"zsh" \
-    atclone"./Util/preconfig && ./configure --prefix='$ZPFX'" \
-    atpull"./configure --prefix='$ZPFX'" \
-    make"install PREFIX='$ZPFX'"
-
-  zinit light "zsh-users/zsh"
+  zinit id-as"zsh" as"null" from"gh" nocompile \
+    atclone'./Util/preconfig && ./configure --prefix="$ZPFX"' \
+    atpull'./configure --prefix="$ZPFX"' \
+    make"install" for @zsh-users/zsh
 }


### PR DESCRIPTION
Hi
I thought that I'll make the PR that will:
- change from the classic syntax to the new for-syntax so that new users get familiar with it,
- use quoted `$ZPFX` as now Zinit expands it in the install-time ices – this will make the `recall` build a nicer command,
- uplift a few minor things like `as"null"` in the `zsh` compilation or no `blockf` as it's not needed.
